### PR TITLE
test/msgr: fix ComplexTest fail when using DPDK protocal stack

### DIFF
--- a/src/test/msgr/test_async_networkstack.cc
+++ b/src/test/msgr/test_async_networkstack.cc
@@ -461,10 +461,12 @@ TEST_P(NetworkWorkerTest, ComplexTest) {
     }
     ConnectedSocket cli_socket, srv_socket;
     if (worker->id == 1) {
-      while (!*listen_p) {
+      while (!*listen_p || stack->support_local_listen_table()) {
         usleep(50);
         r = worker->connect(bind_addr, options, &cli_socket);
         ASSERT_EQ(0, r);
+	if (stack->support_local_listen_table())
+		break;
       }
     }
 


### PR DESCRIPTION
   The DPDK protocol stack failed to run ComplexTest. When testing the DPDK
    protocol stack, the same session will be received by the same queue by the
    RSS. The test case ComplexTest uses two CPUs to run the server and client
    respectively. The message sent by the client cannot be forwarded to the
    server, so the test fails. When support_local_listen_table() is true,
    let the client connect to the server on the same CPU and the test pass.

    Signed-off-by: Chunsong Feng <fengchunsong@huawei.com>

