### PR TITLE
msg/async/dpdk:  dpdk protocol stack should ignore zero length

### DIFF
--- a/src/msg/async/dpdk/DPDKStack.h
+++ b/src/msg/async/dpdk/DPDKStack.h
@@ -141,6 +141,11 @@ class NativeConnectedSocketImpl : public ConnectedSocketImpl {
     uint64_t seglen = 0;
     while (len < available && left_pbrs--) {
       seglen = pb->length();
+      // Buffer length is zero, no need to send, so skip it
+      if (seglen == 0) {
+             ++pb;
+             continue;
+      }
       if (len + seglen > available) {
         // don't continue if we enough at least 1 fragment since no available
         // space for next ptr.

--- a/src/msg/async/dpdk/IPChecksum.cc
+++ b/src/msg/async/dpdk/IPChecksum.cc
@@ -25,6 +25,8 @@
 #include "IPChecksum.h"
 
 void checksummer::sum(const char* data, size_t len) {
+  if (len == 0)
+    return;
   auto orig_len = len;
   if (odd) {
     csum += uint8_t(*data++);


### PR DESCRIPTION
The payload length of messenger protocalV2 is allowed, so the dpdk protocol stack should ignore zero length.

Signed-off-by: Chunsong Feng <fengchunsong@huawei.com>
