### PR TITLE
cmake: Add dpdk numa support

### DIFF
--- a/cmake/modules/BuildDPDK.cmake
+++ b/cmake/modules/BuildDPDK.cmake
@@ -95,8 +95,13 @@ function(do_build_dpdk dpdk_dir)
     BUILD_COMMAND ${make_cmd} O=${dpdk_dir} CC=${CMAKE_C_COMPILER} EXTRA_CFLAGS=-fPIC
     BUILD_IN_SOURCE 1
     INSTALL_COMMAND "true")
+  if(NUMA_FOUND)
+    set(numa "y")
+  else()
+    set(numa "n")
+  endif()
   ExternalProject_Add_Step(dpdk-ext patch-config
-    COMMAND ${CMAKE_MODULE_PATH}/patch-dpdk-conf.sh ${dpdk_dir} ${machine} ${arch}
+    COMMAND ${CMAKE_MODULE_PATH}/patch-dpdk-conf.sh ${dpdk_dir} ${machine} ${arch} ${numa}
     DEPENDEES configure
     DEPENDERS build)
   # easier to adjust the config
@@ -161,6 +166,9 @@ function(do_export_dpdk dpdk_dir)
     list(APPEND DPDK_ARCHIVES "${dpdk_${c}_LIBRARY}")
   endforeach()
 
+  if(NUMA_FOUND)
+    set(dpdk_numa ",numa")
+  endif()
   add_library(dpdk::dpdk INTERFACE IMPORTED)
   add_dependencies(dpdk::dpdk
     ${DPDK_LIBRARIES})
@@ -168,7 +176,7 @@ function(do_export_dpdk dpdk_dir)
   set_target_properties(dpdk::dpdk PROPERTIES
     INTERFACE_INCLUDE_DIRECTORIES ${DPDK_INCLUDE_DIR}
     INTERFACE_LINK_LIBRARIES
-    "-Wl,--whole-archive $<JOIN:${DPDK_ARCHIVES}, > -Wl,--no-whole-archive")
+    "-Wl,--whole-archive $<JOIN:${DPDK_ARCHIVES}, > -Wl,--no-whole-archive -Wl,pthread,dl${dpdk_numa}")
   if(dpdk_rte_CFLAGS)
     set_target_properties(dpdk::dpdk PROPERTIES
       INTERFACE_COMPILE_OPTIONS "${dpdk_rte_CFLAGS}")
@@ -176,6 +184,7 @@ function(do_export_dpdk dpdk_dir)
 endfunction()
 
 function(build_dpdk dpdk_dir)
+  find_package(NUMA QUIET)
   if(NOT TARGET dpdk-ext)
     do_build_dpdk(${dpdk_dir})
   endif()

--- a/cmake/modules/FindNUMA.cmake
+++ b/cmake/modules/FindNUMA.cmake
@@ -1,0 +1,16 @@
+# - Find libnuma
+# Find the numa library and includes
+#
+# NUMA_INCLUDE_DIR - where to find numa.h, etc.
+# NUMA_LIBRARIES - List of libraries when using numa.
+# NUMA_FOUND - True if numa found.
+
+find_path(NUMA_INCLUDE_DIR numa.h)
+find_library(NUMA_LIBRARIES numa)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(numa DEFAULT_MSG NUMA_LIBRARIES NUMA_INCLUDE_DIR)
+
+mark_as_advanced(
+	NUMA_LIBRARIES
+	NUMA_INCLUDE_DIR)

--- a/cmake/modules/patch-dpdk-conf.sh
+++ b/cmake/modules/patch-dpdk-conf.sh
@@ -17,6 +17,8 @@ machine=$1
 shift
 arch=$1
 shift
+numa=$1
+shift
 
 setconf CONFIG_RTE_MACHINE "${machine}"
 setconf CONFIG_RTE_ARCH "${arch}"
@@ -52,4 +54,4 @@ setconf CONFIG_RTE_TEST_PMD n
 setconf CONFIG_RTE_MBUF_REFCNT_ATOMIC n
 
 # balanced allocation of hugepages
-setconf CONFIG_RTE_EAL_NUMA_AWARE_HUGEPAGES n
+setconf CONFIG_RTE_EAL_NUMA_AWARE_HUGEPAGES "${numa}"


### PR DESCRIPTION
Find and link the numa library for DPDK.

Signed-off-by: Hu Ye <yehu5@huawei.com>
Signed-off-by: Chunsong Feng <fengchunsong@huawei.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
