### PR TITLE
test/kvstore_bench: Fix double free errors

### DIFF
--- a/src/test/kv_store_bench.cc
+++ b/src/test/kv_store_bench.cc
@@ -420,7 +420,7 @@ int KvStoreBench::test_teuthology_aio(next_gen_t distr,
       break;
     }
 
-    delete cb_args;
+    //delete cb_args;
   }
 
   op_avail.wait(l, [this] { return ops_in_flight <= 0; });


### PR DESCRIPTION
  In line 423(in function KvStoreBench::test_teuthology_aio), "delete cb_arg" will cause double free error, because kvs->aio_xxx() is asynchronous function, it will return immediately after calling, so "delete cb_arg" will be called immediately to release cb_arg, but aio_callback_timed, cb_arg will be used again, and "delete cb_arg" again at the end. Cause program error;
  So delete this line and let aio_callback_timed to "delete cb_arg".

Signed-off-by: Xuqiang Chen <chenxuqiang3@hisilicon.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
