### PR TITLE
crypto/openssl: update to use evp interface

### DIFF
--- a/src/crypto/openssl/openssl_crypto_accel.cc
+++ b/src/crypto/openssl/openssl_crypto_accel.cc
@@ -13,8 +13,68 @@
  */
 
 #include "crypto/openssl/openssl_crypto_accel.h"
-#include <openssl/aes.h>
+#include <openssl/evp.h>
+#include <openssl/engine.h>
+#include "common/debug.h"
 
+// -----------------------------------------------------------------------------
+#define dout_context g_ceph_context
+#define dout_subsys ceph_subsys_crypto
+#undef dout_prefix
+#define dout_prefix _prefix(_dout)
+
+static ostream&
+_prefix(std::ostream* _dout)
+{
+  return *_dout << "OpensslCryptoAccel: ";
+}
+// -----------------------------------------------------------------------------
+
+#define EVP_SUCCESS 1
+#define AES_ENCRYPT 1
+#define AES_DECRYPT 0
+
+bool evp_transform(unsigned char* out, const unsigned char* in, size_t size,
+                   const unsigned char* iv,
+                   const unsigned char* key,
+                   ENGINE* engine,
+                   const EVP_CIPHER* const type,
+                   const bool encrypt)
+{
+  using pctx_t = std::unique_ptr<EVP_CIPHER_CTX, decltype(&::EVP_CIPHER_CTX_free)>;
+  pctx_t pctx{ EVP_CIPHER_CTX_new(), EVP_CIPHER_CTX_free };
+
+  if (!pctx) {
+    derr << "failed to create evp cipher context" << dendl;
+    return false;
+  }
+
+  if (EVP_CipherInit_ex(pctx.get(), type, engine, key, iv, encrypt) != EVP_SUCCESS) {
+    derr << "EVP_CipherInit_ex failed" << dendl;
+    return false;
+  }
+
+  if (EVP_CIPHER_CTX_set_padding(pctx.get(), 0) != EVP_SUCCESS) {
+    derr << "failed to disable PKCS padding" << dendl;
+    return false;
+  }
+
+  int len_update = 0;
+  if (EVP_CipherUpdate(pctx.get(), out, &len_update, in, size) != EVP_SUCCESS) {
+    derr << "EVP_CipherUpdate failed" << dendl;
+    return false;
+  }
+  
+  int len_final = 0;
+  if (EVP_CipherFinal_ex(pctx.get(), out + len_update, &len_final) != EVP_SUCCESS) {
+    derr << "EVP_CipherFinal_ex failed" << dendl;
+    return false;
+  }
+
+  ceph_assert(len_final == 0);
+  return (len_update + len_final) == static_cast<int>(size);
+}
+                        
 bool OpenSSLCryptoAccel::cbc_encrypt(unsigned char* out, const unsigned char* in, size_t size,
                              const unsigned char (&iv)[AES_256_IVSIZE],
                              const unsigned char (&key)[AES_256_KEYSIZE])
@@ -23,14 +83,12 @@ bool OpenSSLCryptoAccel::cbc_encrypt(unsigned char* out, const unsigned char* in
     return false;
   }
 
-  AES_KEY aes_key;
-  if (AES_set_encrypt_key(const_cast<unsigned char*>(&key[0]), 256, &aes_key) < 0)
-    return false;
-
-  AES_cbc_encrypt(const_cast<unsigned char*>(in), out, size, &aes_key,
-                  const_cast<unsigned char*>(&iv[0]), AES_ENCRYPT);
-  return true;
+  return evp_transform(out, in, size, const_cast<unsigned char*>(&iv[0]),
+                       const_cast<unsigned char*>(&key[0]),
+                       nullptr, // Hardware acceleration engine can be used in the future
+                       EVP_aes_256_cbc(), AES_ENCRYPT);
 }
+                             
 bool OpenSSLCryptoAccel::cbc_decrypt(unsigned char* out, const unsigned char* in, size_t size,
                              const unsigned char (&iv)[AES_256_IVSIZE],
                              const unsigned char (&key)[AES_256_KEYSIZE])
@@ -39,11 +97,8 @@ bool OpenSSLCryptoAccel::cbc_decrypt(unsigned char* out, const unsigned char* in
     return false;
   }
 
-  AES_KEY aes_key;
-  if (AES_set_decrypt_key(const_cast<unsigned char*>(&key[0]), 256, &aes_key) < 0)
-    return false;
-
-  AES_cbc_encrypt(const_cast<unsigned char*>(in), out, size, &aes_key,
-                  const_cast<unsigned char*>(&iv[0]), AES_DECRYPT);
-  return true;
+  return evp_transform(out, in, size, const_cast<unsigned char*>(&iv[0]),
+                       const_cast<unsigned char*>(&key[0]),
+                       nullptr, // Hardware acceleration engine can be used in the future
+                       EVP_aes_256_cbc(), AES_DECRYPT);
 }


### PR DESCRIPTION
the openssl AES encryption optimized with AES-NI using EVP API is around 6x faster than the `AES_cbc_encrypt` implementation, and it supports using engine outside to accelerate when needed. so this patch modify the `cbc_encrypt/cbc_decrypt` implementation to use EVP API.

this could bring considerable performance improvements, for example unittest:

before
```
[==========] Running 15 tests from 1 test case.
[----------] Global test environment set-up.
[----------] 15 tests from TestRGWCrypto
[ RUN      ] TestRGWCrypto.verify_AES_256_CBC_identity
[       OK ] TestRGWCrypto.verify_AES_256_CBC_identity (640 ms)
[ RUN      ] TestRGWCrypto.verify_AES_256_CBC_identity_2
[       OK ] TestRGWCrypto.verify_AES_256_CBC_identity_2 (1097 ms)
[ RUN      ] TestRGWCrypto.verify_AES_256_CBC_identity_3
[       OK ] TestRGWCrypto.verify_AES_256_CBC_identity_3 (1604 ms)
[ RUN      ] TestRGWCrypto.verify_AES_256_CBC_size_0_15
[       OK ] TestRGWCrypto.verify_AES_256_CBC_size_0_15 (4 ms)
[ RUN      ] TestRGWCrypto.verify_AES_256_CBC_identity_last_block
[       OK ] TestRGWCrypto.verify_AES_256_CBC_identity_last_block (1402 ms)
[ RUN      ] TestRGWCrypto.verify_RGWGetObj_BlockDecrypt_ranges
[       OK ] TestRGWCrypto.verify_RGWGetObj_BlockDecrypt_ranges (145 ms)
[ RUN      ] TestRGWCrypto.verify_RGWGetObj_BlockDecrypt_chunks
[       OK ] TestRGWCrypto.verify_RGWGetObj_BlockDecrypt_chunks (149 ms)
[ RUN      ] TestRGWCrypto.check_RGWGetObj_BlockDecrypt_fixup
[       OK ] TestRGWCrypto.check_RGWGetObj_BlockDecrypt_fixup (0 ms)
[ RUN      ] TestRGWCrypto.check_RGWGetObj_BlockDecrypt_fixup_simple
[       OK ] TestRGWCrypto.check_RGWGetObj_BlockDecrypt_fixup_simple (0 ms)
[ RUN      ] TestRGWCrypto.check_RGWGetObj_BlockDecrypt_fixup_non_aligned_obj_size
[       OK ] TestRGWCrypto.check_RGWGetObj_BlockDecrypt_fixup_non_aligned_obj_size (0 ms)
[ RUN      ] TestRGWCrypto.check_RGWGetObj_BlockDecrypt_fixup_non_aligned_part_size
[       OK ] TestRGWCrypto.check_RGWGetObj_BlockDecrypt_fixup_non_aligned_part_size (0 ms)
[ RUN      ] TestRGWCrypto.check_RGWGetObj_BlockDecrypt_fixup_non_aligned
[       OK ] TestRGWCrypto.check_RGWGetObj_BlockDecrypt_fixup_non_aligned (0 ms)
[ RUN      ] TestRGWCrypto.check_RGWGetObj_BlockDecrypt_fixup_invalid_ranges
[       OK ] TestRGWCrypto.check_RGWGetObj_BlockDecrypt_fixup_invalid_ranges (0 ms)
[ RUN      ] TestRGWCrypto.verify_RGWPutObj_BlockEncrypt_chunks
[       OK ] TestRGWCrypto.verify_RGWPutObj_BlockEncrypt_chunks (474 ms)
[ RUN      ] TestRGWCrypto.verify_Encrypt_Decrypt
[       OK ] TestRGWCrypto.verify_Encrypt_Decrypt (2 ms)
[----------] 15 tests from TestRGWCrypto (5517 ms total)

[----------] Global test environment tear-down
[==========] 15 tests from 1 test case ran. (5517 ms total)
[  PASSED  ] 15 tests.
```

after
```
[==========] Running 15 tests from 1 test case.
[----------] Global test environment set-up.
[----------] 15 tests from TestRGWCrypto
[ RUN      ] TestRGWCrypto.verify_AES_256_CBC_identity
[       OK ] TestRGWCrypto.verify_AES_256_CBC_identity (111 ms)
[ RUN      ] TestRGWCrypto.verify_AES_256_CBC_identity_2
[       OK ] TestRGWCrypto.verify_AES_256_CBC_identity_2 (543 ms)
[ RUN      ] TestRGWCrypto.verify_AES_256_CBC_identity_3
[       OK ] TestRGWCrypto.verify_AES_256_CBC_identity_3 (381 ms)
[ RUN      ] TestRGWCrypto.verify_AES_256_CBC_size_0_15
[       OK ] TestRGWCrypto.verify_AES_256_CBC_size_0_15 (5 ms)
[ RUN      ] TestRGWCrypto.verify_AES_256_CBC_identity_last_block
[       OK ] TestRGWCrypto.verify_AES_256_CBC_identity_last_block (339 ms)
[ RUN      ] TestRGWCrypto.verify_RGWGetObj_BlockDecrypt_ranges
[       OK ] TestRGWCrypto.verify_RGWGetObj_BlockDecrypt_ranges (22 ms)
[ RUN      ] TestRGWCrypto.verify_RGWGetObj_BlockDecrypt_chunks
[       OK ] TestRGWCrypto.verify_RGWGetObj_BlockDecrypt_chunks (25 ms)
[ RUN      ] TestRGWCrypto.check_RGWGetObj_BlockDecrypt_fixup
[       OK ] TestRGWCrypto.check_RGWGetObj_BlockDecrypt_fixup (0 ms)
[ RUN      ] TestRGWCrypto.check_RGWGetObj_BlockDecrypt_fixup_simple
[       OK ] TestRGWCrypto.check_RGWGetObj_BlockDecrypt_fixup_simple (0 ms)
[ RUN      ] TestRGWCrypto.check_RGWGetObj_BlockDecrypt_fixup_non_aligned_obj_size
[       OK ] TestRGWCrypto.check_RGWGetObj_BlockDecrypt_fixup_non_aligned_obj_size (0 ms)
[ RUN      ] TestRGWCrypto.check_RGWGetObj_BlockDecrypt_fixup_non_aligned_part_size
[       OK ] TestRGWCrypto.check_RGWGetObj_BlockDecrypt_fixup_non_aligned_part_size (0 ms)
[ RUN      ] TestRGWCrypto.check_RGWGetObj_BlockDecrypt_fixup_non_aligned
[       OK ] TestRGWCrypto.check_RGWGetObj_BlockDecrypt_fixup_non_aligned (0 ms)
[ RUN      ] TestRGWCrypto.check_RGWGetObj_BlockDecrypt_fixup_invalid_ranges
[       OK ] TestRGWCrypto.check_RGWGetObj_BlockDecrypt_fixup_invalid_ranges (0 ms)
[ RUN      ] TestRGWCrypto.verify_RGWPutObj_BlockEncrypt_chunks
[       OK ] TestRGWCrypto.verify_RGWPutObj_BlockEncrypt_chunks (109 ms)
[ RUN      ] TestRGWCrypto.verify_Encrypt_Decrypt
[       OK ] TestRGWCrypto.verify_Encrypt_Decrypt (1 ms)
[----------] 15 tests from TestRGWCrypto (1536 ms total)

[----------] Global test environment tear-down
[==========] 15 tests from 1 test case ran. (1537 ms total)
[  PASSED  ] 15 tests.
```
Signed-off-by: Hang Li <lihang48@hisilicon.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
