### PR TITLE
msg/async/dpdk: Use hash map to manage mbuf to release

### DIFF
--- a/src/common/legacy_config_opts.h
+++ b/src/common/legacy_config_opts.h
@@ -180,7 +180,6 @@ OPTION(ms_dpdk_hw_flow_control, OPT_BOOL)
 // Weighing of a hardware network queue relative to a software queue (0=no work, 1=     equal share)")
 OPTION(ms_dpdk_hw_queue_weight, OPT_FLOAT)
 OPTION(ms_dpdk_debug_allow_loopback, OPT_BOOL)
-OPTION(ms_dpdk_rx_buffer_count_per_core, OPT_INT)
 
 OPTION(inject_early_sigterm, OPT_BOOL)
 

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -1243,10 +1243,6 @@ std::vector<Option> get_global_options() {
     .set_default(false)
     .set_description(""),
 
-    Option("ms_dpdk_rx_buffer_count_per_core", Option::TYPE_INT, Option::LEVEL_ADVANCED)
-    .set_default(8192)
-    .set_description(""),
-
     Option("inject_early_sigterm", Option::TYPE_BOOL, Option::LEVEL_DEV)
     .set_default(false)
     .set_description("send ourselves a SIGTERM early during startup"),

--- a/src/msg/async/dpdk/DPDK.cc
+++ b/src/msg/async/dpdk/DPDK.cc
@@ -530,21 +530,6 @@ bool DPDKQueuePair::init_rx_mbuf_pool()
       return false;
     }
 
-    //
-    // allocate more data buffer
-    int bufs_count =  cct->_conf->ms_dpdk_rx_buffer_count_per_core - mbufs_per_queue_rx;
-    int mz_flags = RTE_MEMZONE_1GB|RTE_MEMZONE_SIZE_HINT_ONLY;
-    std::string mz_name = "rx_buffer_data" + std::to_string(_qid);
-    const struct rte_memzone *mz = rte_memzone_reserve_aligned(mz_name.c_str(),
-          mbuf_data_size*bufs_count, _pktmbuf_pool_rx->socket_id, mz_flags, mbuf_data_size);
-    ceph_assert(mz);
-    void* m = mz->addr;
-    for (int i = 0; i < bufs_count; i++) {
-      ceph_assert(m);
-      _alloc_bufs.push_back(m);
-      m += mbuf_data_size;
-    }
-
     if (rte_eth_rx_queue_setup(_dev_port_idx, _qid, default_ring_size,
                                rte_eth_dev_socket_id(_dev_port_idx),
                                _dev->def_rx_conf(), _pktmbuf_pool_rx) < 0) {
@@ -727,11 +712,19 @@ inline Tub<Packet> DPDKQueuePair::from_mbuf_lro(rte_mbuf* m)
 
     _frags.emplace_back(fragment{data, rte_pktmbuf_data_len(m)});
     _bufs.push_back(data);
+    _rx_free_pkts.insert({data, m});
   }
 
   auto del = std::bind(
           [this](std::vector<char*> &bufs) {
-            for (auto&& b : bufs) { _alloc_bufs.push_back(b); }
+            for (auto&& b : bufs) {
+               auto it = _rx_free_pkts.find(b);
+               if (it != _rx_free_pkts.end()) {
+                       rte_mbuf* mbuf = it->second;
+                       _rx_free_bufs.push_back(mbuf);
+                       _rx_free_pkts.erase(it);
+               }
+           }
           }, std::move(_bufs));
   return Packet(
       _frags.begin(), _frags.end(), make_deleter(std::move(del)));
@@ -739,34 +732,24 @@ inline Tub<Packet> DPDKQueuePair::from_mbuf_lro(rte_mbuf* m)
 
 inline Tub<Packet> DPDKQueuePair::from_mbuf(rte_mbuf* m)
 {
-  _rx_free_pkts.push_back(m);
   _num_rx_free_segs += m->nb_segs;
 
   if (!_dev->hw_features_ref().rx_lro || rte_pktmbuf_is_contiguous(m)) {
     char* data = rte_pktmbuf_mtod(m, char*);
+    _rx_free_pkts.insert({data, m});
 
     return Packet(fragment{data, rte_pktmbuf_data_len(m)},
-                  make_deleter([this, data] { _alloc_bufs.push_back(data); }));
+                  make_deleter([this, data] {
+                       auto it = _rx_free_pkts.find(data);
+                       if (it != _rx_free_pkts.end()) {
+                               rte_mbuf* mbuf = it->second;
+                               _rx_free_bufs.push_back(mbuf);
+                               _rx_free_pkts.erase(it);
+                       }
+                 }));
   } else {
     return from_mbuf_lro(m);
   }
-}
-
-inline bool DPDKQueuePair::refill_one_cluster(rte_mbuf* head)
-{
-  for (; head != nullptr; head = head->next) {
-    if (!refill_rx_mbuf(head, mbuf_data_size, _alloc_bufs)) {
-      //
-      // If we failed to allocate a new buffer - push the rest of the
-      // cluster back to the free_packets list for a later retry.
-      //
-      _rx_free_pkts.push_back(head);
-      return false;
-    }
-    _rx_free_bufs.push_back(head);
-  }
-
-  return true;
 }
 
 bool DPDKQueuePair::rx_gc(bool force)
@@ -774,23 +757,9 @@ bool DPDKQueuePair::rx_gc(bool force)
   if (_num_rx_free_segs >= rx_gc_thresh || force) {
     ldout(cct, 10) << __func__ << " free segs " << _num_rx_free_segs
                    << " thresh " << rx_gc_thresh
-                   << " free pkts " << _rx_free_pkts.size()
+                   << " free bufs " << _rx_free_bufs.size()
                    << dendl;
 
-    while (!_rx_free_pkts.empty()) {
-      //
-      // Use back() + pop_back() semantics to avoid an extra
-      // _rx_free_pkts.clear() at the end of the function - clear() has a
-      // linear complexity.
-      //
-      auto m = _rx_free_pkts.back();
-      _rx_free_pkts.pop_back();
-
-      if (!refill_one_cluster(m)) {
-        ldout(cct, 1) << __func__ << " get new mbuf failed " << dendl;
-        break;
-      }
-    }
     for (auto&& m : _rx_free_bufs) {
       rte_pktmbuf_prefree_seg(m);
     }

--- a/src/msg/async/dpdk/DPDK.h
+++ b/src/msg/async/dpdk/DPDK.h
@@ -588,37 +588,8 @@ class DPDKQueuePair {
     return sent;
   }
 
-  /**
-   * Allocate a new data buffer and set the mbuf to point to it.
-   *
-   * Do some DPDK hacks to work on PMD: it assumes that the buf_addr
-   * points to the private data of RTE_PKTMBUF_HEADROOM before the actual
-   * data buffer.
-   *
-   * @param m mbuf to update
-   */
-  static bool refill_rx_mbuf(rte_mbuf* m, size_t size,
-                             std::vector<void*> &datas) {
-    if (datas.empty())
-      return false;
-    void *data = datas.back();
-    datas.pop_back();
-
-    //
-    // Set the mbuf to point to our data.
-    //
-    // Do some DPDK hacks to work on PMD: it assumes that the buf_addr
-    // points to the private data of RTE_PKTMBUF_HEADROOM before the
-    // actual data buffer.
-    //
-    m->buf_addr      = (char*)data - RTE_PKTMBUF_HEADROOM;
-    m->buf_physaddr  = rte_mem_virt2phy(data) - RTE_PKTMBUF_HEADROOM;
-    return true;
-  }
-
   bool init_rx_mbuf_pool();
   bool rx_gc(bool force=false);
-  bool refill_one_cluster(rte_mbuf* head);
 
   /**
    * Polls for a burst of incoming packets. This function will not block and
@@ -660,7 +631,6 @@ class DPDKQueuePair {
   circular_buffer<Packet> _proxy_packetq;
   stream<Packet> _rx_stream;
   circular_buffer<Packet> _tx_packetq;
-  std::vector<void*> _alloc_bufs;
 
   PerfCounters *perf_logger;
   DPDKDevice* _dev;
@@ -668,7 +638,7 @@ class DPDKQueuePair {
   EventCenter *center;
   uint8_t _qid;
   rte_mempool *_pktmbuf_pool_rx;
-  std::vector<rte_mbuf*> _rx_free_pkts;
+  std::unordered_map<char *, rte_mbuf*> _rx_free_pkts;
   std::vector<rte_mbuf*> _rx_free_bufs;
   std::vector<fragment> _frags;
   std::vector<char*> _bufs;


### PR DESCRIPTION
Using the message rte_mem_virt2phy to fill the mbuf to release the memory,
perf observe rte_mem_virt2phy is a hot function, it go to the kernel for
address translation, become a hot function.Use hash map to manage the
mappings of messages and mbuf, use message address to find mbuf for release.

Signed-off-by: Chunsong Feng <fengchunsong@huawei.com>
Signed-off-by: luo rixin <luorixin@huawei.com>

Currently rte_mem_virt2phy accounts for 11%, and there are kernel calls. 
   Samples: 56K of event 'cycles', 4000 Hz, Event count (approx.): 32612107569 lost: 0/0 drop: 0/0
  Children      Self  Shared Object                      Symbol
-   11.55%     0.03%  ceph_perf_msgr_client212kaconn64k  [.] rte_mem_virt2phy                                                 
   - 7.67% rte_mem_virt2phy                                                                                                   
      - 3.94% __open64                                                                                                        
         - 3.87% el0_svc                                                                                                      
            - el0_svc_handler                                                                                                 
               - 3.86% el0_svc_common                                                                                         
                  - 3.68% __arm64_sys_openat                                                                                  
                     - 3.73% do_sys_open                                                                                      
                        - 2.79% do_filp_open                                                                                  
                           - 2.88% path_openat                                                                                
                              + 1.45% link_path_walk.part.11                                                                  
                              + 0.77% do_last                                                                                 
                              + 0.63% alloc_empty_file                                                                        
      - 2.41% __libc_read                                                                                                     
         + 2.26% el0_svc                                                                                                      
      - 1.17% __close                                                                                                         
         - 0.77% work_pending                                                                                                 
            - do_notify_resume                                                                                                
               - 0.63% task_work_run    
Using the 512KB package length test ./ceph_perf_msgr_client 172.19.56.252:4567 128 1 2000 1 524288.After optimization, el0_svc_common decreased by 1.2%, memcpy increased by 9.18%, and hns3_xmit_pkts increased by 6.99%.
# Event 'cycles'
#
# Baseline  Delta Abs  Shared Object                      Symbol
# ........  .........  .................................  ............................................................................................
#
    48.41%     +9.18%  libc-2.27.so                       [.] __memcpy_generic
               +6.99%  ceph_perf_msgr_client212kmap       [.] hns3_xmit_pkts
               +2.97%  ceph_perf_msgr_client212kmap       [.] DPDKQueuePair::tx_buf::from_packet_copy
               +1.83%  ceph_perf_msgr_client212kmap       [.] PerfCounters::inc
               +1.22%  ceph_perf_msgr_client212kmap       [.] tcp<ipv4_traits>::tcb::data_segment_acked
     1.32%     -1.20%  [kernel.kallsyms]                  [k] el0_svc_common
               +0.92%  ceph_perf_msgr_client212kmap       [.] AsyncConnection::handle_write
               +0.66%  ceph_perf_msgr_client212kmap       [.] EventCenter::delete_time_event
               +0.64%  ceph_perf_msgr_client212kmap       [.] ceph::buffer::v14_2_0::ptr::release
     0.66%     +0.59%  [kernel.kallsyms]                  [k] arch_cpu_idle
               +0.59%  ceph_perf_msgr_client212kmap       [.] interface::dispatch_packet
               +0.59%  ceph_perf_msgr_client212kmap       [.] EventCenter::create_time_event
               +0.55%  ceph_perf_msgr_client212kmap       [.] EventCenter::process_events
               +0.50%  ceph_perf_msgr_client212kmap       [.] std::_Hashtable<char*, std::pair<char* const, rte_mbuf*>, std::allocator<std::pair<char*
  
before optimization:
Total op 2000 run time 99934968us, bw = 1280.83MB/s
after optimization:
Total op 2000 run time 78687214us, bw = 1626.69MB/s

