### PR TITLE
msg/async/rdma: avoid enqueue_dead_qp deadlock

### DIFF
--- a/src/msg/async/rdma/RDMAStack.cc
+++ b/src/msg/async/rdma/RDMAStack.cc
@@ -415,7 +415,6 @@ Infiniband::QueuePair* RDMADispatcher::get_qp(uint32_t qp)
 
 void RDMADispatcher::enqueue_dead_qp(uint32_t qpn)
 {
-  std::lock_guard l{lock};
   auto it = qp_conns.find(qpn);
   if (it == qp_conns.end()) {
     lderr(cct) << __func__ << " QP [" << qpn << "] is not registered." << dendl;
@@ -462,6 +461,7 @@ void RDMADispatcher::handle_tx_event(ibv_wc *cqe, int n)
 
     // If it's beacon WR, enqueue the QP to be destroyed later
     if (response->wr_id == BEACON_WRID) {
+      std::lock_guard l{lock};
       enqueue_dead_qp(response->qp_num);
       continue;
     }


### PR DESCRIPTION
In RDMADispatcher::handle_async_event, when case
IBV_EVENT_QP_LAST_WQE_REACHED matched, before enqueue_dead_qp has lock,
in enqueue_dead_qp also has lock, result in deadlock. So enqueue_dead_qp
might be lockless.

Fixes: https://tracker.ceph.com/issues/44298
Signed-off-by: Chunsong Feng <fengchunsong@huawei.com>
Signed-off-by: yehu <yehu5@huawei.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
