### PR TITLE
blk/kernel: Enable io_uring on aarch64

### DIFF
--- a/src/blk/kernel/io_uring.cc
+++ b/src/blk/kernel/io_uring.cc
@@ -3,7 +3,7 @@
 
 #include "io_uring.h"
 
-#if defined(HAVE_LIBURING) && defined(__x86_64__)
+#if defined(HAVE_LIBURING) && defined(__x86_64__) || defined(HAVE_LIBURING) && defined(__aarch64__)
 
 #include "liburing.h"
 #include <sys/epoll.h>
@@ -223,7 +223,7 @@ bool ioring_queue_t::supported()
   return true;
 }
 
-#else // #if defined(HAVE_LIBURING) && defined(__x86_64__)
+#else // #if defined(HAVE_LIBURING) && defined(__x86_64__) || defined(HAVE_LIBURING) && defined(__aarch64__)
 
 struct ioring_data {};
 
@@ -264,4 +264,4 @@ bool ioring_queue_t::supported()
   return false;
 }
 
-#endif // #if defined(HAVE_LIBURING) && defined(__x86_64__)
+#endif // #if defined(HAVE_LIBURING) && defined(__x86_64__) || defined(HAVE_LIBURING) && defined(__aarch64__)

--- a/systemd/ceph-osd@.service.in
+++ b/systemd/ceph-osd@.service.in
@@ -12,6 +12,7 @@ ExecStart=/usr/bin/ceph-osd -f --cluster ${CLUSTER} --id %i --setuser ceph --set
 ExecStartPre=@CMAKE_INSTALL_FULL_LIBEXECDIR@/ceph/ceph-osd-prestart.sh --cluster ${CLUSTER} --id %i
 LimitNOFILE=1048576
 LimitNPROC=1048576
+LimitMEMLOCK=infinity
 LockPersonality=true
 MemoryDenyWriteExecute=true
 # Need NewPrivileges via `sudo smartctl`


### PR DESCRIPTION
Enable io_uring on aarch64.

Signed-off-by: Xuqiang Chen <chenxuqiang3@hisilicon.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
