### PR TITLE
cmake: link DPDK shared libraries to avoid DPDK initialization failure

### DIFF
--- a/cmake/modules/Finddpdk.cmake
+++ b/cmake/modules/Finddpdk.cmake
@@ -48,7 +48,6 @@ set(components
   mbuf
   mempool
   mempool_ring
-  mempool_stack
   net
   pci
   pmd_af_packet
@@ -66,6 +65,8 @@ set(components
   pmd_ring
   pmd_sfc_efx
   pmd_vmxnet3_uio
+  pmd_hns3
+  pmd_hinic
   ring
   timer)
 
@@ -79,11 +80,7 @@ foreach(c ${components})
     get_target_property(DPDK_rte_${c}_LIBRARY
       ${dpdk_lib} IMPORTED_LOCATION)
   else()
-    find_library(DPDK_rte_${c}_LIBRARY
-      NAMES
-        # use static library
-        ${CMAKE_STATIC_LIBRARY_PREFIX}rte_${c}${CMAKE_STATIC_LIBRARY_SUFFIX}
-        rte_${c}
+    find_library(DPDK_rte_${c}_LIBRARY rte_${c}
       HINTS
         ENV DPDK_DIR
         ${dpdk_LIBRARY_DIRS}
@@ -135,7 +132,8 @@ if(dpdk_FOUND)
     find_package(Threads QUIET)
     list(APPEND _dpdk_libs
       Threads::Threads
-      dpdk::cflags)
+      dpdk::cflags
+      numa)
     set_target_properties(dpdk::dpdk PROPERTIES
       INTERFACE_LINK_LIBRARIES "${_dpdk_libs}"
       INTERFACE_INCLUDE_DIRECTORIES "${dpdk_INCLUDE_DIRS}")

--- a/src/pybind/mgr/dashboard/frontend/cypress/integration/orchestrator/01-hosts.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/integration/orchestrator/01-hosts.e2e-spec.ts
@@ -21,8 +21,20 @@ describe('Hosts page', () => {
       hosts.add(hostname, true);
     });
 
-    it('should delete a host and add it back', function () {
+    it('should drain and delete a host and then add it back', function () {
       const host = Cypress._.last(this.hosts)['name'];
+
+      // should drain the host first before deleting
+      hosts.editLabels(host, ['_no_schedule'], true);
+      hosts.clickHostTab(host, 'Daemons');
+      cy.get('cd-host-details').within(() => {
+        // draining will take some time to complete.
+        // since we don't know how many daemons will be
+        // running in this host in future putting the wait
+        // to 15s
+        cy.wait(15000);
+        hosts.getTableCount('total').should('be.eq', 0);
+      });
       hosts.delete(host);
 
       // add it back


### PR DESCRIPTION
The common_async_dpdk library depends on the dpdk librte_eal file.
If the static library is used, the dependency is transferred to
libceph-common. By default, libceph-common uses the PUBLIC keyword,
the keyword PUBLIC determines that both the application and
libceph-common link to dpdk librte_eal.a. As a result, the global
variables in dpdk librte_eal.a has two copies. So link DPDK shared
libs to avoid DPDK initialization failure.

Fixes: https://tracker.ceph.com/issues/42861

Signed-off-by: Chunsong Feng <fengchunsong@huawei.com>
Signed-off-by: luorixin <luorixin@huawei.com>